### PR TITLE
Potential fix for code scanning alert no. 10: Use of insecure SSL/TLS version

### DIFF
--- a/backend/verification/domain_checker.py
+++ b/backend/verification/domain_checker.py
@@ -29,6 +29,7 @@ class DomainChecker:
     async def _check_ssl(self, domain: str) -> bool:
         # Check SSL certificate
         context = ssl.create_default_context()
+        context.minimum_version = ssl.TLSVersion.TLSv1_2
         try:
             with socket.create_connection((domain, 443), timeout=10) as sock:
                 with context.wrap_socket(sock, server_hostname=domain):


### PR DESCRIPTION
Potential fix for [https://github.com/MWANGAZA-LAB/twiga-scan/security/code-scanning/10](https://github.com/MWANGAZA-LAB/twiga-scan/security/code-scanning/10)

To fix the issue, we will explicitly set the `minimum_version` attribute of the SSL context created by `ssl.create_default_context()` to `ssl.TLSVersion.TLSv1_2`. This ensures that only TLSv1.2 or higher is used for secure connections, regardless of the Python version or runtime environment. The change will be made in the `_check_ssl` method of the `DomainChecker` class, where the SSL context is created.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
